### PR TITLE
Add workflow for building and publishing docs

### DIFF
--- a/.github/workflow/documentation.yml
+++ b/.github/workflow/documentation.yml
@@ -1,0 +1,27 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        uses: andstor/jsdoc-action@v1
+        with:
+          source_dir: ./src
+          output_dir: ./out
+          template_name: minami
+          front_page: README.md
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_dir: ./out


### PR DESCRIPTION
By using the [jsdoc-action](https://github.com/andstor/jsdoc-action), the process of generating and publishing JavaScript documentation can be automated. It uses [JSDoc](https://github.com/andstor/jsdoc-action) for generating the docs.